### PR TITLE
support <slot>

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -122,67 +122,97 @@ describe('Basic', function() {
       });
     });
 
+    describe('ShadowDOM v0', function() {
+      if (!Element.prototype.createShadowRoot) {
+        console.log('ShadowDOM v0 is not supported by the browser.');
+        return;
+      }
+      let fixture, host;
 
-    if (!document.createElement('div').createShadowRoot) {
-      console.log('ShadowDOM v0 is not supported by the browser.');
-    } else {
-      it('should apply inside shadow trees', function() {
-        const fixture = document.querySelector('#fixture');
+      beforeEach(function() {
+        fixture = document.querySelector('#fixture');
         fixture.inert = false;
-        const host = document.createElement('div');
+        host = document.createElement('div');
         fixture.appendChild(host);
-        const shadowRoot = host.createShadowRoot();
+        host.createShadowRoot();
+      });
+
+      afterEach(function() {
+        fixture.removeChild(host);
+      });
+
+      it('should apply inside shadow trees', function() {
         const shadowButton = document.createElement('button');
         shadowButton.textContent = 'Shadow button';
-        shadowRoot.appendChild(shadowButton);
+        host.shadowRoot.appendChild(shadowButton);
         fixture.inert = true;
         expect(isUnfocusable(shadowButton)).to.equal(true);
       });
 
       it('should apply inert styles inside shadow trees', function() {
-        const fixture = document.querySelector('#fixture');
-        const host = document.createElement('div');
-        fixture.appendChild(host);
-        const shadowRoot = host.createShadowRoot();
         const shadowButton = document.createElement('button');
         shadowButton.textContent = 'Shadow button';
-        shadowRoot.appendChild(shadowButton);
+        host.shadowRoot.appendChild(shadowButton);
         shadowButton.inert = true;
         expect(getComputedStyle(shadowButton).pointerEvents).to.equal('none');
       });
 
-      it('should apply inside shadow trees distributed content (ShadowDOM v0)', function() {
-        const fixture = document.querySelector('#fixture');
-        fixture.inert = false;
-        const host = document.createElement('div');
-        fixture.appendChild(host);
-        const shadowRoot = host.createShadowRoot();
-        shadowRoot.appendChild(document.createElement('content'));
+      it('should apply inside shadow trees distributed content', function() {
+        host.shadowRoot.appendChild(document.createElement('content'));
         const distributedButton = document.createElement('button');
         distributedButton.textContent = 'Distributed button';
         host.appendChild(distributedButton);
         fixture.inert = true;
         expect(isUnfocusable(distributedButton)).to.equal(true);
       });
-    }
+    });
 
-    if (!document.createElement('div').attachShadow) {
-      console.log('ShadowDOM v1 is not supported by the browser.');
-    } else {
-      it('should apply inside shadow trees distributed content (ShadowDOM v1)', function() {
-        const fixture = document.querySelector('#fixture');
+    describe('ShadowDOM v1', function() {
+      if (!Element.prototype.attachShadow) {
+        console.log('ShadowDOM v1 is not supported by the browser.');
+        return;
+      }
+      let fixture, host;
+
+      beforeEach(function() {
+        fixture = document.querySelector('#fixture');
         fixture.inert = false;
-        const host = document.createElement('div');
+        host = document.createElement('div');
         fixture.appendChild(host);
-        const shadowRoot = host.attachShadow({mode: 'open'});
-        shadowRoot.appendChild(document.createElement('slot'));
+        host.attachShadow({
+          mode: 'open'
+        });
+      });
+
+      afterEach(function() {
+        fixture.removeChild(host);
+      });
+
+      it('should apply inside shadow trees', function() {
+        const shadowButton = document.createElement('button');
+        shadowButton.textContent = 'Shadow button';
+        host.shadowRoot.appendChild(shadowButton);
+        fixture.inert = true;
+        expect(isUnfocusable(shadowButton)).to.equal(true);
+      });
+
+      it('should apply inert styles inside shadow trees', function() {
+        const shadowButton = document.createElement('button');
+        shadowButton.textContent = 'Shadow button';
+        host.shadowRoot.appendChild(shadowButton);
+        shadowButton.inert = true;
+        expect(getComputedStyle(shadowButton).pointerEvents).to.equal('none');
+      });
+
+      it('should apply inside shadow trees distributed content', function() {
+        host.shadowRoot.appendChild(document.createElement('slot'));
         const distributedButton = document.createElement('button');
         distributedButton.textContent = 'Distributed button';
         host.appendChild(distributedButton);
         fixture.inert = true;
         expect(isUnfocusable(distributedButton)).to.equal(true);
       });
-    }
+    });
   });
 
   describe('nested inert regions', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -122,38 +122,67 @@ describe('Basic', function() {
       });
     });
 
-    it('should apply inside shadow trees', function() {
-      const fixture = document.querySelector('#fixture');
-      fixture.inert = false;
-      const host = document.createElement('div');
-      // Skip this test is Shadow DOM is not supported by the browser
-      if (!host.createShadowRoot) {
-        return;
-      }
-      fixture.appendChild(host);
-      const shadowRoot = host.createShadowRoot();
-      const shadowButton = document.createElement('button');
-      shadowButton.textContent = 'Shadow button';
-      shadowRoot.appendChild(shadowButton);
-      fixture.inert = true;
-      expect(isUnfocusable(shadowButton)).to.equal(true);
-    });
 
-    it('should apply inert styles inside shadow trees', function() {
-      const fixture = document.querySelector('#fixture');
-      const host = document.createElement('div');
-      // Skip this test is Shadow DOM is not supported by the browser
-      if (!host.createShadowRoot) {
-        return;
-      }
-      fixture.appendChild(host);
-      const shadowRoot = host.createShadowRoot();
-      const shadowButton = document.createElement('button');
-      shadowButton.textContent = 'Shadow button';
-      shadowRoot.appendChild(shadowButton);
-      shadowButton.inert = true;
-      expect(getComputedStyle(shadowButton).pointerEvents).to.equal('none');
-    });
+    if (!document.createElement('div').createShadowRoot) {
+      console.log('ShadowDOM v0 is not supported by the browser.');
+    } else {
+      it('should apply inside shadow trees', function() {
+        const fixture = document.querySelector('#fixture');
+        fixture.inert = false;
+        const host = document.createElement('div');
+        fixture.appendChild(host);
+        const shadowRoot = host.createShadowRoot();
+        const shadowButton = document.createElement('button');
+        shadowButton.textContent = 'Shadow button';
+        shadowRoot.appendChild(shadowButton);
+        fixture.inert = true;
+        expect(isUnfocusable(shadowButton)).to.equal(true);
+      });
+
+      it('should apply inert styles inside shadow trees', function() {
+        const fixture = document.querySelector('#fixture');
+        const host = document.createElement('div');
+        fixture.appendChild(host);
+        const shadowRoot = host.createShadowRoot();
+        const shadowButton = document.createElement('button');
+        shadowButton.textContent = 'Shadow button';
+        shadowRoot.appendChild(shadowButton);
+        shadowButton.inert = true;
+        expect(getComputedStyle(shadowButton).pointerEvents).to.equal('none');
+      });
+
+      it('should apply inside shadow trees distributed content (ShadowDOM v0)', function() {
+        const fixture = document.querySelector('#fixture');
+        fixture.inert = false;
+        const host = document.createElement('div');
+        fixture.appendChild(host);
+        const shadowRoot = host.createShadowRoot();
+        shadowRoot.appendChild(document.createElement('content'));
+        const distributedButton = document.createElement('button');
+        distributedButton.textContent = 'Distributed button';
+        host.appendChild(distributedButton);
+        fixture.inert = true;
+        expect(isUnfocusable(distributedButton)).to.equal(true);
+      });
+    }
+
+    if (!document.createElement('div').attachShadow) {
+      console.log('ShadowDOM v1 is not supported by the browser.');
+    } else {
+      it('should apply inside shadow trees distributed content (ShadowDOM v1)', function() {
+        const fixture = document.querySelector('#fixture');
+        fixture.inert = false;
+        const host = document.createElement('div');
+        fixture.appendChild(host);
+        const shadowRoot = host.attachShadow({mode: 'open'});
+        shadowRoot.appendChild(document.createElement('slot'));
+        const distributedButton = document.createElement('button');
+        distributedButton.textContent = 'Distributed button';
+        host.appendChild(distributedButton);
+        fixture.inert = true;
+        expect(isUnfocusable(distributedButton)).to.equal(true);
+      });
+    }
   });
 
   describe('nested inert regions', function() {


### PR DESCRIPTION
Fixes https://github.com/WICG/inert/issues/15 by supporting `<slot>`.
Implemented to work both in `ShadowDOM v0` or `ShadowDOM v1` through feature checks like control if `getDistributedNodes` or `assignedNodes` exist.
Updated the tests with feature checks for ShadowDOM v0/v1 as well.
I refrained from adding Chrome beta (Canary) as a platform in `package.json` since it is not stable.