### PR TITLE
Fix issue in IE11

### DIFF
--- a/src/inert.js
+++ b/src/inert.js
@@ -127,7 +127,7 @@ class InertRoot {
       if (root)
         activeElement = root.activeElement;
     }
-    if (startNode.contains(activeElement))
+    if (startNode.contains && startNode.contains(activeElement))
       activeElement.blur();
   }
 


### PR DESCRIPTION
I was getting one error similar to https://github.com/WICG/inert/issues/55 and https://github.com/WICG/inert/issues/44

So this PR just check if it has the method `contains`, before call it