### PR TITLE
Tests should run against Sauce before an npm publish.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/inert.js",
   "scripts": {
     "build": "rollup -c",
-    "prepublishOnly": "npm run test",
+    "prepublishOnly": "SAUCE=true npm run test",
     "test": "npm run build && karma start"
   },
   "repository": {


### PR DESCRIPTION
This should force the `npm test` command that runs as part of `npm publish` to run the full suite of sauce tests.