### PR TITLE
Bug fixing for adding new elements

### DIFF
--- a/src/inert.js
+++ b/src/inert.js
@@ -230,8 +230,14 @@ class InertRoot {
       if (record.type === 'childList') {
         // Manage added nodes
         slice.call(record.addedNodes).forEach(function(node) {
+          this._newElementsAdded = true;
           this._makeSubtreeUnfocusable(node);
         }, this);
+        if (record.addedNodes.length) {
+          setTimeout(() => {
+            this._newElementsAdded = false;
+          });
+        }
 
         // Un-manage removed nodes
         slice.call(record.removedNodes).forEach(function(node) {
@@ -240,7 +246,9 @@ class InertRoot {
       } else if (record.type === 'attributes') {
         if (record.attributeName === 'tabindex') {
           // Re-initialise inert node if tabindex changes
-          this._manageNode(target);
+          if (!this._newElementsAdded) {
+            this._manageNode(target);
+          }
         } else if (target !== this._rootElement &&
                    record.attributeName === 'inert' &&
                    target.hasAttribute('inert')) {

--- a/test/specs/reapply-tabindex.spec.js
+++ b/test/specs/reapply-tabindex.spec.js
@@ -49,4 +49,20 @@ describe('Reapply existing tabindex', function() {
       }
     });
   });
+
+  it('should set properly tabindex for elements added later in the inert root', function(done) {
+    var divRoot = document.createElement('div');
+    divRoot.inert = true;
+    var button1 = document.createElement('button');
+    var button2 = document.createElement('button');
+    divRoot.appendChild(button1);
+    divRoot.appendChild(button2); // we need to add at least two focusable elements in order for the test to pass
+    // adding a timeout in order to enter the next event loop, due to the mutationObserver events
+    setTimeout(function() {
+      divRoot.inert = false;
+      expect(button1.tabIndex).to.equal(0);
+      expect(button2.tabIndex).to.equal(0);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
When an inert element gets new focusable elements, it will set wrong tabindex on those, right after the parent element will become active again.

Steps to reproduce:
- set inert to an element.
- add later few buttons inside.
- remove the inert attribute.
- the newly added buttons will have tabindex -1 even if no tabindex was provided before.