### PR TITLE
Don't save tabindex set by inert as saved tabindex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2177,9 +2177,9 @@
       }
     },
     "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.4.tgz",
+      "integrity": "sha512-8I1sgZHfVwcSOY6mSGpVU3lw/GSIZvusg8dD2+OGehCJpOhQRLNcH0qb9upQnOH4XhgxxFJSg6E2kx95deb1Tw==",
       "dev": true,
       "requires": {
         "boom": "5.x.x"

--- a/src/inert.js
+++ b/src/inert.js
@@ -518,8 +518,6 @@ class InertManager {
     let inertNode = this._managedNodes.get(node);
     if (inertNode !== undefined) { // node was already in an inert subtree
       inertNode.addInertRoot(inertRoot);
-      // Update saved tabindex value if necessary
-      inertNode.ensureUntabbable();
     } else {
       inertNode = new InertNode(node, inertRoot);
     }

--- a/test/specs/reapply-tabindex.spec.js
+++ b/test/specs/reapply-tabindex.spec.js
@@ -62,7 +62,7 @@ describe('Reapply existing tabindex', function() {
         expect(button.tabIndex).to.equal(-1);
 
         divRoot.inert = false;
-        expect(button1.tabIndex).to.equal(0);
+        expect(button.tabIndex).to.equal(0);
         done();
       });
     });

--- a/test/specs/reapply-tabindex.spec.js
+++ b/test/specs/reapply-tabindex.spec.js
@@ -59,7 +59,7 @@ describe('Reapply existing tabindex', function() {
 
       // adding a timeout in order to enter the next event loop, due to the mutationObserver events
       setTimeout(function() {
-        expect(button1.tabIndex).to.equal(-1);
+        expect(button.tabIndex).to.equal(-1);
 
         divRoot.inert = false;
         expect(button1.tabIndex).to.equal(0);

--- a/test/specs/reapply-tabindex.spec.js
+++ b/test/specs/reapply-tabindex.spec.js
@@ -54,7 +54,7 @@ describe('Reapply existing tabindex', function() {
       var divRoot = document.createElement('div');
       document.body.appendChild(divRoot);
       divRoot.inert = true;
-      var button1 = document.createElement('button');
+      var button = document.createElement('button');
       divRoot.appendChild(button1);
 
       // adding a timeout in order to enter the next event loop, due to the mutationObserver events

--- a/test/specs/reapply-tabindex.spec.js
+++ b/test/specs/reapply-tabindex.spec.js
@@ -55,7 +55,7 @@ describe('Reapply existing tabindex', function() {
       document.body.appendChild(divRoot);
       divRoot.inert = true;
       var button = document.createElement('button');
-      divRoot.appendChild(button1);
+      divRoot.appendChild(button);
 
       // adding a timeout in order to enter the next event loop, due to the mutationObserver events
       setTimeout(function() {

--- a/test/specs/reapply-tabindex.spec.js
+++ b/test/specs/reapply-tabindex.spec.js
@@ -49,4 +49,21 @@ describe('Reapply existing tabindex', function() {
       }
     });
   });
+
+  it('should set tabindex correctly for elements added later in the inert root', function(done) {
+      var divRoot = document.createElement('div');
+      document.body.appendChild(divRoot);
+      divRoot.inert = true;
+      var button1 = document.createElement('button');
+      divRoot.appendChild(button1);
+
+      // adding a timeout in order to enter the next event loop, due to the mutationObserver events
+      setTimeout(function() {
+        expect(button1.tabIndex).to.equal(-1);
+
+        divRoot.inert = false;
+        expect(button1.tabIndex).to.equal(0);
+        done();
+      });
+    });
 });


### PR DESCRIPTION
This was causing issues with elements added to an inert root, as the mutation observer would observe the tabindex changing when the element was managed, and then re-manage the element, saving '-1' as the saved tabindex, meaning that when the element was unmanaged it would write '-1' back as the tabindex.