### PR TITLE
Update rollup config to create a named umd/amd define call in dist

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,9 @@ export default [
     output: {
       file: 'dist/inert.js',
       format: 'umd',
+      amd: {
+        id: 'inert'
+      }
     },
     plugins: [
       babel({
@@ -19,6 +22,9 @@ export default [
     output: {
       file: 'dist/inert.min.js',
       format: 'umd',
+      amd: {
+        id: 'inert'
+      },
       sourcemap: true,
     },
     plugins: [


### PR DESCRIPTION
This is an updated form of PR #115, containing the correct Rollup configuration options to create a named define. This fixes issues when an external library includes `inert` asynchronously in a RequireJS context. The error thrown is described here: https://requirejs.org/docs/errors.html#mismatch