### PR TITLE
Define property flag

### DIFF
--- a/src/inert.js
+++ b/src/inert.js
@@ -690,12 +690,12 @@ const inertManager = new InertManager(document);
 
 if (!Element.prototype.hasOwnProperty('inert')) {
   Object.defineProperty(Element.prototype, 'inert', {
-                          enumerable: true,
-                          get: function() {
-                            return this.hasAttribute('inert');
-                          },
-                          set: function(inert) {
-                            inertManager.setInert(this, inert);
-                          },
-                        });
+    enumerable: true,
+    get: function() {
+      return this.hasAttribute('inert');
+    },
+    set: function(inert) {
+      inertManager.setInert(this, inert);
+    },
+  });
 }

--- a/src/inert.js
+++ b/src/inert.js
@@ -688,12 +688,14 @@ function addInertStyle(node) {
 
 const inertManager = new InertManager(document);
 
-Object.defineProperty(Element.prototype, 'inert', {
-                        enumerable: true,
-                        get: function() {
-                          return this.hasAttribute('inert');
-                        },
-                        set: function(inert) {
-                          inertManager.setInert(this, inert);
-                        },
-                      });
+if (!Element.prototype.hasOwnProperty('inert')) {
+  Object.defineProperty(Element.prototype, 'inert', {
+    enumerable: true,
+    get: function() {
+      return this.hasAttribute('inert');
+    },
+    set: function(inert) {
+      inertManager.setInert(this, inert);
+    },
+  });
+}

--- a/src/inert.js
+++ b/src/inert.js
@@ -690,12 +690,12 @@ const inertManager = new InertManager(document);
 
 if (!Element.prototype.hasOwnProperty('inert')) {
   Object.defineProperty(Element.prototype, 'inert', {
-    enumerable: true,
-    get: function() {
-      return this.hasAttribute('inert');
-    },
-    set: function(inert) {
-      inertManager.setInert(this, inert);
-    },
-  });
+                          enumerable: true,
+                          get: function() {
+                            return this.hasAttribute('inert');
+                          },
+                          set: function(inert) {
+                            inertManager.setInert(this, inert);
+                          },
+                        });
 }


### PR DESCRIPTION
Fixes #122 

Add a check for `inert` before defining the property.