### PR TITLE
Use documentElement if document.body does not exist

### DIFF
--- a/src/inert.js
+++ b/src/inert.js
@@ -588,7 +588,7 @@ class InertManager {
     }, this);
 
     // Comment this out to use programmatic API only.
-    this._observer.observe(this._document.body, {attributes: true, subtree: true, childList: true});
+    this._observer.observe(this._document.body || this._document.documentElement, {attributes: true, subtree: true, childList: true});
   }
 
   /**


### PR DESCRIPTION
I came across this issue when testing Internet Explorer 10 on https://polyfill.io.