### PR TITLE
Mark repo as host of software development

### DIFF
--- a/w3c.json
+++ b/w3c.json
@@ -1,5 +1,5 @@
  {
     "group":      [80485]
 ,   "contacts":   ["marcoscaceres"]
-,   "repo-type":  "cg-report"
+,   "repo-type":  "tool"
 }


### PR DESCRIPTION
It looks like the repo is now more about the polyfill than spec development, so I'm suggesting to use repo-type: tool instead of cg-report