### PR TITLE
Updated Reference for ESM

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ ensure the version you're using is stable and thoroughly tested.
 This project provides two versions of the polyfill in `package.json`.
 
 - `main`: Points at `dist/inert.js` which is transpiled to ES3.
-- `module`: Points at `src/inert.js` which is _not_ transpiled and uses modern
-  JavaScript. See [#136](https://github.com/WICG/inert/issues/136) if
-  you would like to tell webpack to use the version in `main`.
+- `module`: Points at `dist/inert.esm.js` which is transpiled to ES3.
 
 _If you do want to build from source, make sure you clone the latest tag!_
 


### PR DESCRIPTION
- Updated the reference to the latest build introduced from #161 
- Removed the note related to how to point to "main" in webpack since it is not needed as the previous PR already transpiled the source to ES3, webpack will be able to pick up from there in the default "module" reference.