### PR TITLE
Move new InertManager inside property check

### DIFF
--- a/src/inert.js
+++ b/src/inert.js
@@ -720,10 +720,10 @@
     node.appendChild(style);
   }
 
-  /** @type {!InertManager} */
-  const inertManager = new InertManager(document);
-
   if (!Element.prototype.hasOwnProperty('inert')) {
+    /** @type {!InertManager} */
+    const inertManager = new InertManager(document);
+    
     Object.defineProperty(Element.prototype, 'inert', {
       enumerable: true,
       /** @this {!Element} */


### PR DESCRIPTION
`new InertManager` was executing every time the file was imported instead of creating the instance only when the `inert` property was missing. Moving into the prototype check has resolved the issue for us for the past couple of months.

Fixes #159
Fixes #163 