### PR TITLE
Specify license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,6 @@
     "rollup": "^0.65.0",
     "rollup-plugin-babel": "^3.0.4",
     "rollup-plugin-uglify": "^4.0.0"
-  }
+  },
+  "license": "W3C-20150513"
 }


### PR DESCRIPTION
Set the license field in package.json to the correct SPDX identifier.

https://docs.npmjs.com/cli/v6/configuring-npm/package-json#license

https://spdx.org/licenses/