### PR TITLE
fix: avoid video element to get focus

### DIFF
--- a/src/inert.js
+++ b/src/inert.js
@@ -32,6 +32,7 @@
                                     'iframe',
                                     'object',
                                     'embed',
+                                    'video',
                                     '[contenteditable]'].join(',');
 
   /**


### PR DESCRIPTION
Currently, video elements with the `controls` attribute are being able to get focused, even if its parent has the `inert` attribute
