### PR TITLE
Security Fix: Replace compromised polyfill.io cdn with cloudflare cdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ to download only the polyfills needed by the current browser. Just add the
 following line to the start of your page:
 
 ```html
-<script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Map,Set,Element.prototype.matches,Node.prototype.contains"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=4.8.0&features=Map%2CSet%2CElement.prototype.matches%2CNode.prototype.contains"></script>
 ```
 
 ### Strict Content Security Policy

--- a/demo/index.html
+++ b/demo/index.html
@@ -132,7 +132,7 @@ This work is licensed under the W3C Software and Document License
       </div>
     </section>
 
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Map,Set,Element.prototype.matches,Node.prototype.contains"></script>
+    <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=4.8.0&features=Map%2CSet%2CElement.prototype.matches%2CNode.prototype.contains"></script>
     <script src="https://unpkg.com/wicg-inert"></script>
     <script>
       var toggler = document.querySelector('#toggle');


### PR DESCRIPTION
There has been a polyfill.io cdn supply chain attack. It is advised to remove all references to this cdn immediately.
This PR removes the compromised polyfill.io cdn from the demo index.html file as well as the main readme and replaces them with cloudflare cdn.


Even though it is just referenced in the demo files it is critical to remove it immediately as people reading the docs might use it. Additionally many companies scan their repositories for compromised urls and are now unable to use this package.

Details: https://sansec.io/research/polyfill-supply-chain-attack